### PR TITLE
Git issue regarding broken link

### DIFF
--- a/project.yml
+++ b/project.yml
@@ -1,7 +1,7 @@
 settings:
   name: NetApp Replication
   internal:
-    pdf_enabled: true
+    pdf_enabled: false
   prod:
     pdf_enabled: true
   release_notes_autogen:

--- a/task-get-help.adoc
+++ b/task-get-help.adoc
@@ -10,4 +10,4 @@ summary: NetApp provides support for NetApp Console in a variety of ways. Extens
 :imagesdir: ./media/
 
 [.lead]
-include::https://raw.githubusercontent.com/NetAppDocs/bluexp-family/main/_include/get-help.adoc[]
+include::https://raw.githubusercontent.com/NetAppDocs/console-family/main/_include/get-help.adoc[]


### PR DESCRIPTION
This pull request contains two small but important changes: it updates a documentation include path to point to the correct repository, and disables the PDF export feature for internal builds in the project configuration.

- Documentation update:
  * Changed the include path in `task-get-help.adoc` to reference the `console-family` repository instead of `bluexp-family`.

- Project configuration:
  * Set `pdf_enabled` to `false` for internal builds in `project.yml` to disable PDF export internally.